### PR TITLE
Fix date dropdown to retain municipality code if available

### DIFF
--- a/website/apps/home/templates/home/map.html
+++ b/website/apps/home/templates/home/map.html
@@ -35,7 +35,12 @@
                     <ul class="dropdown-menu">
                         {% for sim in all_sim_with_model %}
                             <li>
+                            {% if municipality_code %}
+                                <a href="{% url 'home.mapview' model_id=sim.sim_model sim_id=sim.id municipality_code=municipality_code %}">{{ sim.date_output_generated }}</a>
+                            {% endif %}
+                            {% if not municipality_code %}
                                 <a href="{% url 'home.mapview' model_id=sim.sim_model sim_id=sim.id %}">{{ sim.date_output_generated }}</a>
+                            {% endif %}
                             </li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
Changed urls in date dropdown to include municipality code if available. This way, if the date is changed through the dropdown, the municipality code is still selected and the chart for that municipality will be shown. If no municipality is selected, it will behave as it was before.