### PR TITLE
Removed name field from upload page and changed upload_job

### DIFF
--- a/website/apps/home/templates/home/upload.html
+++ b/website/apps/home/templates/home/upload.html
@@ -7,62 +7,58 @@
         <div class="col-md-10">
             <form action="" method="post" enctype="multipart/form-data">{% csrf_token %}
                 <div class="form-group">
-                    <label for="simulationNameInput"><strong>Simulation Name</strong></label>
-                    <input type="text" class="form-control" id="simulationNameInput" name="name"
-                           placeholder="Simulation Name">
-                </div>
-
-                <div class="form-group">
                     <label for="simulationInputFile"><strong>Simulation File Input</strong></label>
                     <input type="file" id="simulationInputFile" name="output_file">
                 </div>
-                        <div class="checkbox">
-                            <label>
-                                <input type="checkbox" name="historical"><strong>Historical Data</strong>
-                            </label>
-                        </div>
-                    <input type="submit" class="btn btn-primary" value="Upload"/>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" name="historical"><strong>Historical Data</strong>
+                    </label>
+                </div>
+                <br/>
+                <input type="submit" class="btn btn-primary" value="Upload"/>
             </form>
         </div>
-    <div class="col-md-10">
-        <h3>List of uploads <a class="btn btn-success" href="">{% bootstrap_icon 'refresh' %} Refresh</a> </h3>
-        <table class="table table-hover">
-        <tr>
-            <th>Name</th>
-            <th>Status</th>
-            <th>Progress</th>
-            <th>Started</th>
-            <th>Duration</th>
-            <th>Error message</th>
-            <th>PID</th>
-        </tr>
-        {% for job in jobs %}
-            <tr>
-                <td>{{ job.name }}</td>
-                <td>
-                    {% if job.status == 'Failed' %}
-                    <span style="color:red"><span class="glyphicon glyphicon-warning-sign"></span></span>
-                    {% elif job.status == 'Completed' %}
-                    {% bootstrap_icon 'ok' %}
-                    {% endif %}
-                    {{ job.status }}
-                </td>
-                <td>
-                    {% if job.status == "In Progress" %}
-                    <div class="progress">
-                        <div class="progress-bar" role="progressbar" aria-valuenow="{{ job.progress }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ job.progress }}%">
-                            <span>{{ job.progress }}% Complete</span>
-                        </div>
-                    </div>
-                    {% endif %}
-                </td>
-                <td>{{ job.upload_start_timestamp|default:'' }}</td>
-                <td>{{ job.duration|default:'' }}</td>
-                <td>{{ job.last_error_message|default:'' }}</td>
-                <td>{{ job.pid|default:'' }}</td>
-            </tr>
-        {% endfor %}
-        </table>
-    </div>
+        <div class="col-md-10">
+            <h3>List of uploads <a class="btn btn-success" href="">{% bootstrap_icon 'refresh' %} Refresh</a></h3>
+            <table class="table table-hover">
+                <tr>
+                    <th>Name</th>
+                    <th>Status</th>
+                    <th>Progress</th>
+                    <th>Started</th>
+                    <th>Duration</th>
+                    <th>Error message</th>
+                    <th>PID</th>
+                </tr>
+                {% for job in jobs %}
+                    <tr>
+                        <td>{{ job.name }}</td>
+                        <td>
+                            {% if job.status == 'Failed' %}
+                                <span style="color:red"><span class="glyphicon glyphicon-warning-sign"></span></span>
+                            {% elif job.status == 'Completed' %}
+                                {% bootstrap_icon 'ok' %}
+                            {% endif %}
+                            {{ job.status }}
+                        </td>
+                        <td>
+                            {% if job.status == "In Progress" %}
+                                <div class="progress">
+                                    <div class="progress-bar" role="progressbar" aria-valuenow="{{ job.progress }}"
+                                         aria-valuemin="0" aria-valuemax="100" style="width:{{ job.progress }}%">
+                                        <span>{{ job.progress }}% Complete</span>
+                                    </div>
+                                </div>
+                            {% endif %}
+                        </td>
+                        <td>{{ job.upload_start_timestamp|default:'' }}</td>
+                        <td>{{ job.duration|default:'' }}</td>
+                        <td>{{ job.last_error_message|default:'' }}</td>
+                        <td>{{ job.pid|default:'' }}</td>
+                    </tr>
+                {% endfor %}
+            </table>
+        </div>
     </div>
 {% endblock %}

--- a/website/apps/home/tests/test_views.py
+++ b/website/apps/home/tests/test_views.py
@@ -194,9 +194,7 @@ class Home(TestCase):
         self.client.login(username='admin', password='1')
         response = self.client.post(reverse('simulation.upload'), data={'output_file': io.StringIO("")})
         # Missing parameter: "'name'"
-        self.assertEqual(response.status_code, 200)
-        # self.assertIn("Missing parameter", str(response.content))
-        # self.assertIn("name", str(response.content))
+        self.assertEqual(response.status_code, 302)
 
     def test_upload_view_post_no_historical(self):
         # If "Historical" checkbox is not selected, no "historical" parameter is sent by browser
@@ -228,7 +226,7 @@ class Home(TestCase):
         self.client.login(username='admin', password='1')
         response = self.client.post(
             reverse('simulation.upload'),
-            data={'name': 'test', 'output_file': io.StringIO(''), 'historical': 'no', 'is_test': 'yes'}
+            data={'name': 'test', 'output_file': io.StringIO('test'), 'historical': 'no', 'is_test': 'yes'}
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse('simulation.upload'))

--- a/website/apps/home/tests/test_views.py
+++ b/website/apps/home/tests/test_views.py
@@ -210,13 +210,14 @@ class Home(TestCase):
         self.client.login(username='admin', password='1')
         response = self.client.post(
             reverse('simulation.upload'),
-            data={'name': 'test', 'output_file': io.StringIO(''), 'historical': 'on', 'is_test': 'yes'}
+            data={'name': 'test', 'output_file': io.StringIO(''), 'historical': 'on','is_test': 'yes'}
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse('simulation.upload'))
         time.sleep(0.1)
         self.assertEqual(UploadJob.objects.count(), upload_jobs_count + 1)
-        upload_job = UploadJob.objects.get(name='test')
+        print(UploadJob.objects.get())
+        upload_job = UploadJob.objects.get(name='output_file')
         self.assertEqual(upload_job.historical, True)
         # Note due to "transactional" nature of Django unit tests, it is impossible to test
         # data loading code here
@@ -226,13 +227,13 @@ class Home(TestCase):
         self.client.login(username='admin', password='1')
         response = self.client.post(
             reverse('simulation.upload'),
-            data={'name': 'test', 'output_file': io.StringIO('test'), 'historical': 'no', 'is_test': 'yes'}
+            data={'name': 'test', 'output_file': io.StringIO(''), 'historical': 'no', 'is_test': 'yes'}
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse('simulation.upload'))
         time.sleep(0.1)
         self.assertEqual(UploadJob.objects.count(), upload_jobs_count + 1)
-        upload_job = UploadJob.objects.get(name='test')
+        upload_job = UploadJob.objects.get(name='output_file')
         self.assertEqual(upload_job.historical, False)
         # Note due to "transactional" nature of Django unit tests, it is impossible to test
         # data loading code here

--- a/website/apps/home/tests/test_views.py
+++ b/website/apps/home/tests/test_views.py
@@ -181,7 +181,6 @@ class Home(TestCase):
         self.client.login(username='admin', password='1')
         response = self.client.get(reverse('simulation.upload'))
         self.assertEqual(response.status_code, 200)
-        # self.assertIn('simulationNameInput', str(response.content))
 
     def test_upload_view_post_no_output_file(self):
         self.client.login(username='admin', password='1')
@@ -195,9 +194,9 @@ class Home(TestCase):
         self.client.login(username='admin', password='1')
         response = self.client.post(reverse('simulation.upload'), data={'output_file': io.StringIO("")})
         # Missing parameter: "'name'"
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Missing parameter", str(response.content))
-        self.assertIn("name", str(response.content))
+        self.assertEqual(response.status_code, 200)
+        # self.assertIn("Missing parameter", str(response.content))
+        # self.assertIn("name", str(response.content))
 
     def test_upload_view_post_no_historical(self):
         # If "Historical" checkbox is not selected, no "historical" parameter is sent by browser
@@ -216,7 +215,7 @@ class Home(TestCase):
             data={'name': 'test', 'output_file': io.StringIO(''), 'historical': 'on', 'is_test': 'yes'}
         )
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('home.display_historical'))
+        self.assertEqual(response.url, reverse('simulation.upload'))
         time.sleep(0.1)
         self.assertEqual(UploadJob.objects.count(), upload_jobs_count + 1)
         upload_job = UploadJob.objects.get(name='test')
@@ -232,7 +231,7 @@ class Home(TestCase):
             data={'name': 'test', 'output_file': io.StringIO(''), 'historical': 'no', 'is_test': 'yes'}
         )
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, reverse('home.display_simulations'))
+        self.assertEqual(response.url, reverse('simulation.upload'))
         time.sleep(0.1)
         self.assertEqual(UploadJob.objects.count(), upload_jobs_count + 1)
         upload_job = UploadJob.objects.get(name='test')

--- a/website/apps/home/tests/test_views.py
+++ b/website/apps/home/tests/test_views.py
@@ -181,7 +181,7 @@ class Home(TestCase):
         self.client.login(username='admin', password='1')
         response = self.client.get(reverse('simulation.upload'))
         self.assertEqual(response.status_code, 200)
-        self.assertIn('simulationNameInput', str(response.content))
+        # self.assertIn('simulationNameInput', str(response.content))
 
     def test_upload_view_post_no_output_file(self):
         self.client.login(username='admin', password='1')

--- a/website/apps/home/views/UploadView.py
+++ b/website/apps/home/views/UploadView.py
@@ -40,7 +40,6 @@ class UploadView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     def post(self, request):
         try:
             data_file = request.FILES['output_file']
-            sim_name = request.POST['name']
             is_historical = request.POST.get('historical', "")
             is_test = request.POST.get('is_test', None)
         except KeyError as e:
@@ -52,7 +51,8 @@ class UploadView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
             is_historical = False
 
         job = UploadJob.objects.create(
-            name=sim_name, data_file=data_file, historical=is_historical, created_by=request.user
+            name=str(data_file),
+            data_file=data_file, historical=is_historical, created_by=request.user
         )
 
         if not is_test:
@@ -81,8 +81,5 @@ class UploadView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
             job.save(update_fields=['pid'])
             logger.debug("PID %s started for loading simulation data in background" % p.pid)
 
-        # Redirect to appropriate page whether uploading simulation or historical
-        if is_historical != True:
-            return HttpResponseRedirect(reverse('home.display_simulations'))
-        else:
-            return HttpResponseRedirect(reverse('home.display_historical'))
+        # Redirect to the simulation page
+        return HttpResponseRedirect(reverse('simulation.upload'))


### PR DESCRIPTION
upload_job will have the filename as its name. This is only shown in the background for uploading the file
had to remove assertion statement from test_views. Statement was looking at simulationNameInput which has been removed. Other test fixes include fixing the name that the UploadJob queries on.